### PR TITLE
add 4d support to resample

### DIFF
--- a/tools/preprocess_utils/geometry.py
+++ b/tools/preprocess_utils/geometry.py
@@ -52,11 +52,17 @@ def resample(image,
         image = np.array(image)
 
     if new_shape is None:
-        spacing = np.array([spacing[0], spacing[1], spacing[2]])
+        spacing = np.array(spacing)
         new_shape = np.round(image.shape * spacing / new_spacing)
     else:
         new_shape = np.array(new_shape)
-        new_spacing = tuple((image.shape/new_shape) * spacing) if spacing is not None else None
+        if spacing is not None:
+            if len(spacing) == 4:
+                spacing = spacing[1:]
+            new_spacing = (np.array(image.shape)/new_shape) * np.array(spacing)
+            new_spacing = [float(s) for s in new_spacing]
+        else:
+            new_spacing = None
 
     resize_factor = new_shape / np.array(image.shape)
 


### PR DESCRIPTION
4d序列的spacing传进来长度可能是4，添加了一个判断。
原来的 new_spacing = tuple((np.array(image.shape)/new_shape) * np.array(spacing)) 貌似list里的数还是cupy.array，json序列化不了