### PR TITLE
For cupy<10.0.0 use numpy in this file

### DIFF
--- a/tools/preprocess_utils/values.py
+++ b/tools/preprocess_utils/values.py
@@ -23,9 +23,10 @@ import tools.preprocess_utils.global_var as global_var
 gpu_tag = global_var.get_value('USE_GPU')
 if gpu_tag:
     import cupy as np
+    if int(np.__version__.split(".")[0]) < 10:
+        import numpy as np
 else:
     import numpy as np
-
 
 def label_remap(label, map_dict=None):
     """


### PR DESCRIPTION
cupy.nan_to_num在10.0.0之前参数不一样，看不太懂应该怎么传。aistudio的cuda版本装不上cupy 10。这样可以在aistudio上用cupy预处理